### PR TITLE
ES-58 Smart Locks UI

### DIFF
--- a/src/features/Dashboard/components/LockUnlockCard.tsx
+++ b/src/features/Dashboard/components/LockUnlockCard.tsx
@@ -73,7 +73,6 @@ const LockUnlock = ({ height }: CardProps) => {
           <Button
             size="small"
             variant={isLocked ? "contained" : "outlined"}
-            // color="warning"
             startIcon={<LockOpenIcon />}
             onClick={handleUnlock}
             disabled={!isLocked}

--- a/src/features/Dashboard/components/LockUnlockCard.tsx
+++ b/src/features/Dashboard/components/LockUnlockCard.tsx
@@ -38,60 +38,77 @@ const LockUnlock = ({ height }: CardProps) => {
     setShowAlert(false);
   };
 
-const card = (
-  <React.Fragment>
-    <Typography
-      color={isLocked ? "secondary.main" : "warning.main"}
-      sx={{ 
-        display: 'flex', 
-        alignItems: 'center',
-        fontWeight: theme.typography.h3.fontWeight,
-        mb: 1
-      }}
-    >
-      {isLocked ? <LockIcon sx={{ mr: 1 }} /> : <LockOpenIcon sx={{ mr: 1 }} />}
-      Front Door is {isLocked ? "Locked" : "Unlocked"}</Typography>
+  const card = (
+    <React.Fragment>
+      <Typography
+        color={isLocked ? "secondary.main" : "warning.main"}
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          fontWeight: theme.typography.h3.fontWeight,
+          mb: 1,
+        }}
+      >
+        {isLocked ? (
+          <LockIcon sx={{ mr: 1 }} />
+        ) : (
+          <LockOpenIcon sx={{ mr: 1 }} />
+        )}
+        Front Door is {isLocked ? "Locked" : "Unlocked"}
+      </Typography>
 
-    <Stack direction="row">
-      <CardActions>
-        <Button size="small" variant={isLocked ? "contained" : "outlined"}
-                    startIcon={<LockIcon />}
-                    onClick={handleLock}
-                    disabled={isLocked}
-        >
-          Lock
-        </Button>
-      </CardActions>
-      <CardActions>
-      <Button size="small" variant={isLocked ? "contained" : "outlined"}
-                  // color="warning"
-                  startIcon={<LockOpenIcon />}
-                  onClick={handleUnlock}
-                  disabled={!isLocked}>
-          Unlock
-        </Button>
-      </CardActions>
-    </Stack>
-  </React.Fragment>
-);
+      <Stack direction="row">
+        <CardActions>
+          <Button
+            size="small"
+            variant={isLocked ? "contained" : "outlined"}
+            startIcon={<LockIcon />}
+            onClick={handleLock}
+            disabled={isLocked}
+          >
+            Lock
+          </Button>
+        </CardActions>
+        <CardActions>
+          <Button
+            size="small"
+            variant={isLocked ? "contained" : "outlined"}
+            // color="warning"
+            startIcon={<LockOpenIcon />}
+            onClick={handleUnlock}
+            disabled={!isLocked}
+          >
+            Unlock
+          </Button>
+        </CardActions>
+      </Stack>
+    </React.Fragment>
+  );
 
   return (
-    <Box sx={{ minWidth: 275, height, flex: 1 }}>
-      <Card variant="outlined" sx={{ height: "100%",
+    <Box
+      sx={{ minWidth: 275, flex: 1, height: { xs: height.xs, md: height.md } }}
+    >
+      <Card
+        variant="outlined"
+        sx={{
+          height: "100%",
           p: 1,
-          borderColor: isLocked ? theme.palette.secondary.main : theme.palette.warning.main,
+          borderColor: isLocked
+            ? theme.palette.secondary.main
+            : theme.palette.warning.main,
           borderWidth: 1,
         }}
       >
         {card}
       </Card>
-      
-      <Snackbar 
-        open={showAlert} 
-        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+
+      <Snackbar
+        open={showAlert}
+        anchorOrigin={{ vertical: "top", horizontal: "center" }}
       >
-        <Alert 
-          severity="warning" 
+        <Alert
+          severity="warning"
           variant="filled"
           onClose={handleCloseAlert}
           action={

--- a/src/features/Dashboard/components/LockUnlockCard.tsx
+++ b/src/features/Dashboard/components/LockUnlockCard.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
-import Box from '@mui/material/Box';
-import Card from '@mui/material/Card';
-import CardActions from '@mui/material/CardActions';
-import Button from '@mui/material/Button';
-import Typography from '@mui/material/Typography';
-import Stack from '@mui/material/Stack';
+import * as React from "react";
+import Box from "@mui/material/Box";
+import Card from "@mui/material/Card";
+import CardActions from "@mui/material/CardActions";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
+import Stack from "@mui/material/Stack";
 import Alert from "@mui/material/Alert";
 import Snackbar from "@mui/material/Snackbar";
 import LockIcon from "@mui/icons-material/Lock";
@@ -12,7 +12,11 @@ import LockOpenIcon from "@mui/icons-material/LockOpen";
 import { useTheme } from "@mui/material/styles";
 
 interface CardProps {
-  height: { xs: number; md: number };
+  height: HeightProps;
+}
+interface HeightProps {
+  xs: number;
+  md: number;
 }
 
 const LockUnlock = ({ height }: CardProps) => {
@@ -82,8 +86,20 @@ const LockUnlock = ({ height }: CardProps) => {
   );
 
   return (
-    <Box sx={{ minWidth: 275, height, flex: 1 }}>
-      <Card variant='outlined' sx={{ height: { ...height } }}>
+    <Box
+      sx={{ minWidth: 275, flex: 1, height: { xs: height.xs, md: height.md } }}
+    >
+      <Card
+        variant="outlined"
+        sx={{
+          height: "100%",
+          p: 1,
+          borderColor: isLocked
+            ? theme.palette.secondary.main
+            : theme.palette.warning.main,
+          borderWidth: 1,
+        }}
+      >
         {card}
       </Card>
 

--- a/src/features/Dashboard/components/LockUnlockCard.tsx
+++ b/src/features/Dashboard/components/LockUnlockCard.tsx
@@ -5,6 +5,11 @@ import CardActions from "@mui/material/CardActions";
 import Button from "@mui/material/Button";
 import Typography from "@mui/material/Typography";
 import Stack from "@mui/material/Stack";
+import Alert from "@mui/material/Alert";
+import Snackbar from "@mui/material/Snackbar";
+import LockIcon from "@mui/icons-material/Lock";
+import LockOpenIcon from "@mui/icons-material/LockOpen";
+import { useTheme } from "@mui/material/styles";
 
 interface CardProps {
   height: HeightProps;
@@ -14,17 +19,55 @@ interface HeightProps {
   md: number;
 }
 
+const LockUnlock = ({ height }: CardProps) => {
+  const theme = useTheme();
+  const [isLocked, setIsLocked] = React.useState(true);
+  const [showAlert, setShowAlert] = React.useState(false);
+
+  const handleLock = () => {
+    setIsLocked(true);
+    setShowAlert(false);
+  };
+
+  const handleUnlock = () => {
+    setIsLocked(false);
+    setShowAlert(true);
+  };
+
+  const handleCloseAlert = () => {
+    setShowAlert(false);
+  };
+
 const card = (
   <React.Fragment>
-    <Typography>Front Door is Unlocked</Typography>
+    <Typography
+      color={isLocked ? "secondary.main" : "warning.main"}
+      sx={{ 
+        display: 'flex', 
+        alignItems: 'center',
+        fontWeight: theme.typography.h3.fontWeight,
+        mb: 1
+      }}
+    >
+      {isLocked ? <LockIcon sx={{ mr: 1 }} /> : <LockOpenIcon sx={{ mr: 1 }} />}
+      Front Door is {isLocked ? "Locked" : "Unlocked"}</Typography>
+
     <Stack direction="row">
       <CardActions>
-        <Button size="small" variant="outlined">
+        <Button size="small" variant={isLocked ? "contained" : "outlined"}
+                    startIcon={<LockIcon />}
+                    onClick={handleLock}
+                    disabled={isLocked}
+        >
           Lock
         </Button>
       </CardActions>
       <CardActions>
-        <Button size="small" variant="outlined">
+      <Button size="small" variant={isLocked ? "contained" : "outlined"}
+                  color="warning"
+                  startIcon={<LockOpenIcon />}
+                  onClick={handleUnlock}
+                  disabled={!isLocked}>
           Unlock
         </Button>
       </CardActions>
@@ -32,12 +75,36 @@ const card = (
   </React.Fragment>
 );
 
-export default function OutlinedCard({ height }: CardProps) {
   return (
-    <Box sx={{ minWidth: 275, height, flex: 1 }}>
-      <Card variant="outlined" sx={{ height: "100%" }}>
+<Box sx={{ minWidth: 275, flex: 1, height: { xs: height.xs, md: height.md } }}>
+<Card variant="outlined" sx={{ height: "100%",
+          p: 1,
+          borderColor: isLocked ? theme.palette.secondary.main : theme.palette.warning.main,
+          borderWidth: 1,
+        }}
+      >
         {card}
       </Card>
+      
+      <Snackbar 
+        open={showAlert} 
+        anchorOrigin={{ vertical: 'top', horizontal: 'center' }}
+      >
+        <Alert 
+          severity="warning" 
+          variant="filled"
+          onClose={handleCloseAlert}
+          action={
+            <Button color="inherit" size="small" onClick={handleLock}>
+              Lock Now
+            </Button>
+          }
+        >
+          Your front door is currently unlocked. Click "Lock Now" to secure it.
+        </Alert>
+      </Snackbar>
     </Box>
   );
-}
+};
+
+export default LockUnlock;

--- a/src/features/Dashboard/components/LockUnlockCard.tsx
+++ b/src/features/Dashboard/components/LockUnlockCard.tsx
@@ -64,7 +64,7 @@ const card = (
       </CardActions>
       <CardActions>
       <Button size="small" variant={isLocked ? "contained" : "outlined"}
-                  color="warning"
+                  // color="warning"
                   startIcon={<LockOpenIcon />}
                   onClick={handleUnlock}
                   disabled={!isLocked}>
@@ -76,8 +76,8 @@ const card = (
 );
 
   return (
-<Box sx={{ minWidth: 275, flex: 1, height: { xs: height.xs, md: height.md } }}>
-<Card variant="outlined" sx={{ height: "100%",
+    <Box sx={{ minWidth: 275, height, flex: 1 }}>
+      <Card variant="outlined" sx={{ height: "100%",
           p: 1,
           borderColor: isLocked ? theme.palette.secondary.main : theme.palette.warning.main,
           borderWidth: 1,


### PR DESCRIPTION
-Lock/Unlock component remains on the Dashboard
-As a user, I should be able to have the option to lock and unlock door by clicking button 'Lock" or 'Unlock"
-When unlocked, alert pops up and remains as an alert until user locks door again for security
-When user locks again, alert disappears

![Screenshot 2025-03-15 013822](https://github.com/user-attachments/assets/ecddd696-a82b-4fe2-aba7-60add3d63806)

![Screenshot 2025-03-15 013830](https://github.com/user-attachments/assets/1ba8cf6b-28f7-4244-8521-f6f2a6261150)

Material Icon + Components: 
(https://mui.com/material-ui/material-icons/)
(https://mui.com/material-ui/react-snackbar/)

Jira Ticket: 
(https://jasminepvodev-1739842146260.atlassian.net/browse/ES-58)
