### PR TITLE
ES-97:chore(routing): Connect the routes to dashboard (home page)

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,10 +1,9 @@
 import AppProvider from './Provider';
 import AppRouter from './Router';
-import AppBarResponsive from './components/AppBarResponsive';
+
 function App() {
   return (
     <AppProvider>
-      <AppBarResponsive />
       <AppRouter></AppRouter>
     </AppProvider>
   );

--- a/src/app/Router.tsx
+++ b/src/app/Router.tsx
@@ -1,32 +1,33 @@
-import { BrowserRouter as Router, Routes, Route } from "react-router";
-import HomePage from "./routes/HomePage";
-import RegisterPage from "../features/auth/Register";
-import Login from "../features/Login/Login";
-import GuestParking from "../features/GuestParking/GuestParking";
-import GuestParkingApproved from "../features/GuestParking/GuestParkingApproved";
-import { TenantSupport } from "../features/TenantSupport/TenantSupport";
-import GuestAccess from "../features/GuestAccess/GuestAccess";
-import GuestAccessKey from "../features/GuestAccess/GuestKey";
-import PasswordReset from "../features/PasswordReset/PasswordReset";
-import { SmartPackage } from "../features/SmartPackage/SmartPackage";
-import { PackageDetails } from "../features/SmartPackage/PackageDetails";
-
+import { BrowserRouter as Router, Routes, Route } from 'react-router';
+import HomePage from './routes/HomePage';
+import RegisterPage from '../features/auth/Register';
+import Login from '../features/Login/Login';
+import GuestParking from '../features/GuestParking/GuestParking';
+import GuestParkingApproved from '../features/GuestParking/GuestParkingApproved';
+import { TenantSupport } from '../features/TenantSupport/TenantSupport';
+import GuestAccess from '../features/GuestAccess/GuestAccess';
+import GuestAccessKey from '../features/GuestAccess/GuestKey';
+import PasswordReset from '../features/PasswordReset/PasswordReset';
+import { SmartPackage } from '../features/SmartPackage/SmartPackage';
+import { PackageDetails } from '../features/SmartPackage/PackageDetails';
+import AppBarResponsive from './components/AppBarResponsive';
 
 function AppRouter() {
   return (
     <Router>
+      <AppBarResponsive />
       <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/register" element={<RegisterPage />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/parking" element={<GuestParking />} />
-        <Route path="/parking/approved" element={<GuestParkingApproved />} />
-        <Route path="/tenant-support" element={<TenantSupport />} />
-        <Route path="/guestaccess" element={<GuestAccess />} />
-        <Route path="/guestaccess/key" element={<GuestAccessKey />} />
-        <Route path="/password-reset" element={<PasswordReset />} />
-        <Route path="/smartpackage" element={<SmartPackage />} />
-        <Route path="/smartpackage/:id" element={<PackageDetails />} />
+        <Route path='/' element={<HomePage />} />
+        <Route path='/register' element={<RegisterPage />} />
+        <Route path='/login' element={<Login />} />
+        <Route path='/parking' element={<GuestParking />} />
+        <Route path='/parking/approved' element={<GuestParkingApproved />} />
+        <Route path='/tenant-support' element={<TenantSupport />} />
+        <Route path='/guestaccess' element={<GuestAccess />} />
+        <Route path='/guestaccess/key' element={<GuestAccessKey />} />
+        <Route path='/password-reset' element={<PasswordReset />} />
+        <Route path='/smartpackage' element={<SmartPackage />} />
+        <Route path='/smartpackage/:id' element={<PackageDetails />} />
       </Routes>
     </Router>
   );

--- a/src/app/components/AppBarResponsive.tsx
+++ b/src/app/components/AppBarResponsive.tsx
@@ -10,6 +10,7 @@ import Container from '@mui/material/Container';
 import Avatar from '@mui/material/Avatar';
 import Tooltip from '@mui/material/Tooltip';
 import MenuItem from '@mui/material/MenuItem';
+import { Link } from 'react-router';
 
 const pages = [
   'Tenant Support',
@@ -140,7 +141,13 @@ function ResponsiveAppBar() {
             >
               {settings.map((setting) => (
                 <MenuItem key={setting} onClick={handleCloseUserMenu}>
-                  <Typography sx={{ textAlign: 'center' }}>{setting}</Typography>
+                  {setting === 'Dashboard' ? (
+                    <Link to='/' style={{ textDecoration: 'none', color: 'inherit' }}>
+                      <Typography sx={{ textAlign: 'center' }}>{setting}</Typography>
+                    </Link>
+                  ) : (
+                    <Typography sx={{ textAlign: 'center' }}>{setting}</Typography>
+                  )}
                 </MenuItem>
               ))}
             </Menu>

--- a/src/app/components/AppBarResponsive.tsx
+++ b/src/app/components/AppBarResponsive.tsx
@@ -13,13 +13,50 @@ import MenuItem from '@mui/material/MenuItem';
 import { Link } from 'react-router';
 
 const pages = [
-  'Tenant Support',
-  'Smart Package Locker',
-  'Guest Access',
-  'Guest Parking',
-  'Digital Lease',
+  {
+    name: 'Home',
+    path: '/',
+  },
+  {
+    name: 'Tenant Support',
+    path: '/tenant-support',
+  },
+  {
+    name: 'Smart Package Locker',
+    path: '/smartpackage',
+  },
+  {
+    name: 'Guest Access',
+    path: '/guestaccess',
+  },
+  {
+    name: 'Guest Parking',
+    path: '/parking',
+  },
+  {
+    name: 'Digital Lease',
+    path: '/digital-lease',
+  },
 ];
-const settings = ['Profile', 'Dashboard', 'Logout'];
+
+const settings = [
+  {
+    name: 'Dashboard',
+    path: '/',
+  },
+  {
+    name: 'Login',
+    path: '/login',
+  },
+  {
+    name: 'Register',
+    path: '/register',
+  },
+  {
+    name: 'Forgot Password?',
+    path: '/password-reset',
+  },
+];
 
 function ResponsiveAppBar() {
   const [anchorElNav, setAnchorElNav] = React.useState<null | HTMLElement>(null);
@@ -90,8 +127,10 @@ function ResponsiveAppBar() {
               sx={{ display: { xs: 'block', md: 'none' } }}
             >
               {pages.map((page) => (
-                <MenuItem key={page} onClick={handleCloseNavMenu}>
-                  <Typography sx={{ textAlign: 'center' }}>{page}</Typography>
+                <MenuItem key={page.name} onClick={handleCloseNavMenu}>
+                  <Link to={page.path} style={{ textDecoration: 'none' }}>
+                    <Typography sx={{ textAlign: 'center', color: '#000' }}>{page.name}</Typography>
+                  </Link>
                 </MenuItem>
               ))}
             </Menu>
@@ -140,14 +179,10 @@ function ResponsiveAppBar() {
               onClose={handleCloseUserMenu}
             >
               {settings.map((setting) => (
-                <MenuItem key={setting} onClick={handleCloseUserMenu}>
-                  {setting === 'Dashboard' ? (
-                    <Link to='/' style={{ textDecoration: 'none', color: 'inherit' }}>
-                      <Typography sx={{ textAlign: 'center' }}>{setting}</Typography>
-                    </Link>
-                  ) : (
-                    <Typography sx={{ textAlign: 'center' }}>{setting}</Typography>
-                  )}
+                <MenuItem key={setting.name} onClick={handleCloseUserMenu}>
+                  <Link to={setting.path} style={{ textDecoration: 'none', color: 'inherit' }}>
+                    <Typography sx={{ textAlign: 'center' }}>{setting.name}</Typography>
+                  </Link>
                 </MenuItem>
               ))}
             </Menu>

--- a/src/app/routes/HomePage.tsx
+++ b/src/app/routes/HomePage.tsx
@@ -17,7 +17,7 @@ const HomePage = () => {
           sx={{ display: 'flex', justifyContent: 'center' }}
         >
           <LockUnlock height={height} />
-          <DashboardCard title='One Tap Reporting' height={height} />
+          <DashboardCard title='One Tap Reporting' height={height} path='/tenant-support' />
         </Stack>
 
         <Stack
@@ -25,16 +25,20 @@ const HomePage = () => {
           spacing={2}
           sx={{ display: 'flex', justifyContent: 'center' }}
         >
-          <DashboardCard title='Smart Package Locker' height={otherCardHeight} />
-          <DashboardCard title='Guest Access' height={otherCardHeight} />
+          <DashboardCard
+            title='Smart Package Locker'
+            height={otherCardHeight}
+            path='/smartpackage'
+          />
+          <DashboardCard title='Guest Access' height={otherCardHeight} path='/guestaccess' />
         </Stack>
         <Stack
           direction={{ xs: 'column', md: 'row' }}
           spacing={2}
           sx={{ display: 'flex', justifyContent: 'center' }}
         >
-          <DashboardCard title='Guest Parking' height={otherCardHeight} />
-          <DashboardCard title='Digital Lease' height={otherCardHeight} />
+          <DashboardCard title='Guest Parking' height={otherCardHeight} path='/parking' />
+          <DashboardCard title='Digital Lease' height={otherCardHeight} path='/digital-lease' />
         </Stack>
       </Stack>
     </Container>

--- a/src/features/Dashboard/components/DashboardCard.tsx
+++ b/src/features/Dashboard/components/DashboardCard.tsx
@@ -2,22 +2,26 @@ import Box from '@mui/material/Box';
 import Card from '@mui/material/Card';
 import CardContent from '@mui/material/CardContent';
 import Typography from '@mui/material/Typography';
+import { Link } from 'react-router';
 
 interface CardProps {
   title: string;
   height: { xs: number; md: number };
+  path: string;
 }
 
-export default function OutlinedCard({ title, height }: CardProps) {
+export default function OutlinedCard({ title, height, path }: CardProps) {
   return (
     <Box sx={{ minWidth: 275, flex: 1 }}>
-      <Card variant='outlined' title={title} sx={{ height: height }}>
-        <CardContent>
-          <Typography gutterBottom sx={{ color: 'text.secondary', fontSize: 14 }}>
-            {title}
-          </Typography>
-        </CardContent>
-      </Card>
+      <Link to={path} style={{ textDecoration: 'none' }}>
+        <Card variant='outlined' title={title} sx={{ height: height }}>
+          <CardContent>
+            <Typography gutterBottom sx={{ color: 'text.secondary', fontSize: 14 }}>
+              {title}
+            </Typography>
+          </CardContent>
+        </Card>
+      </Link>
     </Box>
   );
 }

--- a/src/features/Dashboard/components/LockUnlockCard.tsx
+++ b/src/features/Dashboard/components/LockUnlockCard.tsx
@@ -1,15 +1,15 @@
-import * as React from "react";
-import Box from "@mui/material/Box";
-import Card from "@mui/material/Card";
-import CardActions from "@mui/material/CardActions";
-import Button from "@mui/material/Button";
-import Typography from "@mui/material/Typography";
-import Stack from "@mui/material/Stack";
-import Alert from "@mui/material/Alert";
-import Snackbar from "@mui/material/Snackbar";
-import LockIcon from "@mui/icons-material/Lock";
-import LockOpenIcon from "@mui/icons-material/LockOpen";
-import { useTheme } from "@mui/material/styles";
+import * as React from 'react';
+import Box from '@mui/material/Box';
+import Card from '@mui/material/Card';
+import CardActions from '@mui/material/CardActions';
+import Button from '@mui/material/Button';
+import Typography from '@mui/material/Typography';
+import Stack from '@mui/material/Stack';
+import Alert from '@mui/material/Alert';
+import Snackbar from '@mui/material/Snackbar';
+import LockIcon from '@mui/icons-material/Lock';
+import LockOpenIcon from '@mui/icons-material/LockOpen';
+import { useTheme } from '@mui/material/styles';
 
 interface CardProps {
   height: HeightProps;
@@ -41,27 +41,23 @@ const LockUnlock = ({ height }: CardProps) => {
   const card = (
     <React.Fragment>
       <Typography
-        color={isLocked ? "secondary.main" : "warning.main"}
+        color={isLocked ? 'secondary.main' : 'warning.main'}
         sx={{
-          display: "flex",
-          alignItems: "center",
+          display: 'flex',
+          alignItems: 'center',
           fontWeight: theme.typography.h3.fontWeight,
           mb: 1,
         }}
       >
-        {isLocked ? (
-          <LockIcon sx={{ mr: 1 }} />
-        ) : (
-          <LockOpenIcon sx={{ mr: 1 }} />
-        )}
-        Front Door is {isLocked ? "Locked" : "Unlocked"}
+        {isLocked ? <LockIcon sx={{ mr: 1 }} /> : <LockOpenIcon sx={{ mr: 1 }} />}
+        Front Door is {isLocked ? 'Locked' : 'Unlocked'}
       </Typography>
 
-      <Stack direction="row">
+      <Stack direction='row'>
         <CardActions>
           <Button
-            size="small"
-            variant={isLocked ? "contained" : "outlined"}
+            size='small'
+            variant={isLocked ? 'contained' : 'outlined'}
             startIcon={<LockIcon />}
             onClick={handleLock}
             disabled={isLocked}
@@ -71,8 +67,8 @@ const LockUnlock = ({ height }: CardProps) => {
         </CardActions>
         <CardActions>
           <Button
-            size="small"
-            variant={isLocked ? "contained" : "outlined"}
+            size='small'
+            variant={isLocked ? 'contained' : 'outlined'}
             startIcon={<LockOpenIcon />}
             onClick={handleUnlock}
             disabled={!isLocked}
@@ -85,33 +81,26 @@ const LockUnlock = ({ height }: CardProps) => {
   );
 
   return (
-    <Box
-      sx={{ minWidth: 275, flex: 1, height: { xs: height.xs, md: height.md } }}
-    >
+    <Box sx={{ minWidth: 275, flex: 1, height: { xs: height.xs, md: height.md } }}>
       <Card
-        variant="outlined"
+        variant='outlined'
         sx={{
-          height: "100%",
+          height: '100%',
           p: 1,
-          borderColor: isLocked
-            ? theme.palette.secondary.main
-            : theme.palette.warning.main,
+          borderColor: isLocked ? theme.palette.secondary.main : theme.palette.warning.main,
           borderWidth: 1,
         }}
       >
         {card}
       </Card>
 
-      <Snackbar
-        open={showAlert}
-        anchorOrigin={{ vertical: "top", horizontal: "center" }}
-      >
+      <Snackbar open={showAlert} anchorOrigin={{ vertical: 'top', horizontal: 'center' }}>
         <Alert
-          severity="warning"
-          variant="filled"
+          severity='warning'
+          variant='filled'
           onClose={handleCloseAlert}
           action={
-            <Button color="inherit" size="small" onClick={handleLock}>
+            <Button color='inherit' size='small' onClick={handleLock}>
               Lock Now
             </Button>
           }

--- a/src/features/GuestAccess/GuestAccess.tsx
+++ b/src/features/GuestAccess/GuestAccess.tsx
@@ -10,129 +10,128 @@ import {
   FormControl,
   Paper,
   Box,
-} from "@mui/material";
-import { Link } from "react-router";
+} from '@mui/material';
+import { Link } from 'react-router';
 import VpnKeyIcon from '@mui/icons-material/VpnKey';
 
 const GuestAccess = () => {
   return (
     <Container
       sx={{
-        height: "600px",
-        marginTop: "60px",
+        height: '600px',
+        marginTop: '60px',
       }}
     >
       <Paper
         sx={{
-          padding: "20px",
-          borderRadius: "10px",
+          padding: '20px',
+          borderRadius: '10px',
         }}
       >
         <Stack
           sx={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            width: { xs: "auto", sm: 500 },
-            height: "100%",
-            margin: "0 auto",
-            gap: "30px",
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            width: { xs: 'auto', sm: 500 },
+            height: '100%',
+            margin: '0 auto',
+            gap: '30px',
           }}
         >
-
-          <Box 
-            sx={{ 
-              display: "flex", 
-              justifyContent: "center",
-              marginBottom: "-20px"
+          <Box
+            sx={{
+              display: 'flex',
+              justifyContent: 'center',
+              marginBottom: '-20px',
             }}
           >
-            <VpnKeyIcon 
-              sx={{ 
-                fontSize: 60, 
-                color: "primary.main",
-              }} 
+            <VpnKeyIcon
+              sx={{
+                fontSize: 60,
+                color: 'primary.main',
+              }}
             />
           </Box>
-          
+
           <Typography
             sx={{
-              textAlign: "center",
+              textAlign: 'center',
               fontWeight: 500,
-              fontSize: "1.5rem",
-              lineHeight: "1.2",
+              fontSize: '1.5rem',
+              lineHeight: '1.2',
             }}
           >
             Guest Access
           </Typography>
-          
-          <Typography 
-            variant="body2" 
-            color="text.secondary"
-            sx={{ 
-              textAlign: "center",
-              marginTop: "-20px",
-              marginBottom: "10px"
+
+          <Typography
+            variant='body2'
+            color='text.secondary'
+            sx={{
+              textAlign: 'center',
+              marginTop: '-20px',
+              marginBottom: '10px',
             }}
           >
             Generate a temporary access key for your visitors
           </Typography>
-          
-          <InputLabel 
-            sx={{ 
-              width: "100%", 
-              marginBottom: "10px" 
+
+          <InputLabel
+            sx={{
+              width: '100%',
+              marginBottom: '10px',
             }}
           >
             Guest Name
           </InputLabel>
           <TextField
             sx={{
-              width: "100%",
-              marginBottom: "20px",
+              width: '100%',
+              marginBottom: '20px',
             }}
           />
-          
-          <InputLabel 
-            sx={{ 
-              width: "100%", 
-              marginBottom: "10px" 
+
+          <InputLabel
+            sx={{
+              width: '100%',
+              marginBottom: '10px',
             }}
           >
             Time Limit
           </InputLabel>
-          <FormControl 
-            sx={{ 
-              width: "100%", 
-              marginBottom: "20px" 
+          <FormControl
+            sx={{
+              width: '100%',
+              marginBottom: '20px',
             }}
           >
-                <Select defaultValue="1">
-                  <MenuItem value="1">60 minutes</MenuItem>
-                  <MenuItem value="2">2 hours</MenuItem>
-                  <MenuItem value="4">4 hours</MenuItem>
-                  <MenuItem value="8">8 hours</MenuItem>
-                  <MenuItem value="24">24 hours (1 day)</MenuItem>
-                  <MenuItem value="48">48 hours (2 days)</MenuItem>
-                  <MenuItem value="168">1 week</MenuItem>
-                </Select>
-              </FormControl>
+            <Select defaultValue='1'>
+              <MenuItem value='1'>60 minutes</MenuItem>
+              <MenuItem value='2'>2 hours</MenuItem>
+              <MenuItem value='4'>4 hours</MenuItem>
+              <MenuItem value='8'>8 hours</MenuItem>
+              <MenuItem value='24'>24 hours (1 day)</MenuItem>
+              <MenuItem value='48'>48 hours (2 days)</MenuItem>
+              <MenuItem value='168'>1 week</MenuItem>
+            </Select>
+          </FormControl>
           <Link
-            to="/guestaccess/key"
+            to='/guestaccess/key'
             style={{
-              textDecoration: "none",
-              width: "100%",
-              margin: "0 auto",
-              display: "flex",
-              justifyContent: "center",
+              textDecoration: 'none',
+              width: '100%',
+              margin: '0 auto',
+              display: 'flex',
+              justifyContent: 'center',
             }}
           >
             <Button
-              variant="contained"
+              variant='contained'
               sx={{
-                width: "50%",
-                height: "50px",
-                margin: "0 auto",
+                width: '50%',
+                height: '50px',
+                margin: '0 auto',
               }}
             >
               Generate Key

--- a/src/features/GuestAccess/GuestKey.tsx
+++ b/src/features/GuestAccess/GuestKey.tsx
@@ -1,46 +1,39 @@
-import {
-  Container,
-  Stack,
-  Button,
-  Typography,
-  Paper,
-  Box,
-} from "@mui/material";
-import { Link } from "react-router";
-import ArrowBackIcon from "@mui/icons-material/ArrowBack";
+import { Container, Stack, Button, Typography, Paper, Box } from '@mui/material';
+import { Link } from 'react-router';
+import ArrowBackIcon from '@mui/icons-material/ArrowBack';
 
 const GuestAccessKey = () => {
   return (
     <Container
       sx={{
-        height: "600px",
-        marginTop: "60px",
+        height: '600px',
+        marginTop: '60px',
       }}
     >
       <Paper
         sx={{
-          padding: "20px",
-          borderRadius: "10px",
+          padding: '20px',
+          borderRadius: '10px',
         }}
       >
         <Stack
           sx={{
-            display: "flex",
-            flexDirection: "column",
-            alignItems: "center",
-            width: { xs: "auto", sm: 500 },
-            height: "100%",
-            margin: "0 auto",
-            gap: "30px",
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            width: { xs: 'auto', sm: 500 },
+            height: '100%',
+            margin: '0 auto',
+            gap: '30px',
           }}
         >
-          <Box sx={{ alignSelf: "flex-start" }}>
+          <Box sx={{ alignSelf: 'flex-start' }}>
             <Link
-              to="/guestaccess"
+              to='/guestaccess'
               style={{
-                textDecoration: "none",
-                display: "flex",
-                alignItems: "center",
+                textDecoration: 'none',
+                display: 'flex',
+                alignItems: 'center',
               }}
             >
               <ArrowBackIcon />
@@ -50,9 +43,9 @@ const GuestAccessKey = () => {
 
           <Typography
             sx={{
-              textAlign: "center",
+              textAlign: 'center',
               fontWeight: 500,
-              fontSize: "1.5rem",
+              fontSize: '1.5rem',
             }}
           >
             Access Key Generated
@@ -60,21 +53,21 @@ const GuestAccessKey = () => {
 
           <Box
             sx={{
-              backgroundColor: "secondary.main",
-              padding: "20px 40px",
-              borderRadius: "8px",
-              border: "1px solid",
-              borderColor: "primary.main",
-              width: "70%",
-              textAlign: "center",
+              backgroundColor: 'secondary.main',
+              padding: '20px 40px',
+              borderRadius: '8px',
+              border: '1px solid',
+              borderColor: 'primary.main',
+              width: '70%',
+              textAlign: 'center',
             }}
           >
             <Typography
               sx={{
-                fontSize: "2rem",
-                fontWeight: "700",
-                letterSpacing: "0.25rem",
-                color: "primary.main",
+                fontSize: '2rem',
+                fontWeight: '700',
+                letterSpacing: '0.25rem',
+                color: 'primary.main',
               }}
             >
               123456
@@ -83,8 +76,8 @@ const GuestAccessKey = () => {
 
           <Typography
             sx={{
-              textAlign: "center",
-              maxWidth: "80%",
+              textAlign: 'center',
+              maxWidth: '80%',
             }}
           >
             One time code for <strong>Mars Bars</strong>.
@@ -95,22 +88,22 @@ const GuestAccessKey = () => {
           </Typography>
 
           <Link
-            to="/"
+            to='/'
             style={{
-              textDecoration: "none",
-              width: "100%",
-              margin: "0 auto",
-              display: "flex",
-              justifyContent: "center",
+              textDecoration: 'none',
+              width: '100%',
+              margin: '0 auto',
+              display: 'flex',
+              justifyContent: 'center',
             }}
           >
             <Button
-              variant="contained"
+              variant='contained'
               sx={{
-                width: "50%",
-                height: "50px",
-                margin: "0 auto",
-                marginTop: "10px",
+                width: '50%',
+                height: '50px',
+                margin: '0 auto',
+                marginTop: '10px',
               }}
             >
               Back to Dashboard

--- a/src/features/Login/Login.tsx
+++ b/src/features/Login/Login.tsx
@@ -12,6 +12,7 @@ import {
 import { useLoginMutation } from './api/loginApi';
 import { useNavigate } from 'react-router';
 import { useState } from 'react';
+import { Link as RouteLink } from 'react-router';
 
 const Login = () => {
   const [email, setEmail] = useState('');
@@ -129,15 +130,19 @@ const Login = () => {
             >
               {isLoading ? 'Logging in...' : 'Log in'}
             </Button>
+
             <Button
+              component={RouteLink}
+              to='/register'
               variant='contained'
-              sx={{ width: '58%', bgcolor: '#1a3b5d', color: 'white', textTransform: 'none' }}
+              sx={{ width: '58%', bgcolor: '#1a3b5d', textTransform: 'none', color: 'white' }}
             >
               Register
             </Button>
           </Stack>
           <Link
-            href='#'
+            component={RouteLink}
+            to='/password-reset'
             underline='none'
             sx={{ width: '100%', textAlign: 'center', margin: '0 auto' }}
           >


### PR DESCRIPTION
### Description
- Configured the feature routes on the Dashboard page
- Updated the ResponsiveAppBar to allow a user to route back to the dashboard
- Configured the routing within the Login component
- Added a path prop to each Dashboard card for routing

Linked Jira ticket:
[ES-97](https://jasminepvodev-1739842146260.atlassian.net/jira/software/projects/ES/boards/3?selectedIssue=ES-97)

### How to test
1. In your terminal for the frontend repo:
`git checkout ES-97-Connect-the-routes-to-dashboard-home-page`
`npm i`
`npm run dev`<br><br>
2. Navigate to http://localhost:5173/ which will bring you to the Dashboard page
<img width="700" height="500" alt="Screenshot 2025-03-17 at 7 53 20 PM" src="https://github.com/user-attachments/assets/83d9a595-5008-440e-b286-e1389430366b" />
<br><br>
3. Click on each card except the lock/unlock card. Each card will bring you to the correct route for that feature. 

*** NOTE *** The digital lease feature has not been pushed to main as of the creation of this PR, so it will bring you to an empty page. This is expected.<br><br>
4. While in one of the feature routes,  click on the top right user icon and select "Dashboard". This will route you back to the main Dashboard.

<img  width="700" height="500" alt="Screenshot 2025-03-17 at 8 00 39 PM" src="https://github.com/user-attachments/assets/9fd2f242-ada2-49df-9d27-26b1fc3d0d53" /><br><br>
5. Navigate to http://localhost:5173/login. Clicking on the Register button will route you to the register page. Clicking on the "Forgot your password?" link will route you to the password reset page.



[ES-97]: https://jasminepvodev-1739842146260.atlassian.net/browse/ES-97?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ