### PR TITLE
Fix:reset password auth session issues ES-125

### DIFF
--- a/src/features/ResetPassword/api/Resetpasswordapi.ts
+++ b/src/features/ResetPassword/api/Resetpasswordapi.ts
@@ -2,7 +2,7 @@ import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
 export const resetPasswordApi = createApi({
   reducerPath: 'resetPasswordApi',
-  baseQuery: fetchBaseQuery({ baseUrl: 'http://localhost:3000/' }),
+  baseQuery: fetchBaseQuery({ baseUrl: 'http://localhost:3000/', credentials: 'include' }),
   endpoints: (builder) => ({
     updatePassword: builder.mutation<void, { newPassword: string }>({
       query: (body) => ({
@@ -16,6 +16,5 @@ export const resetPasswordApi = createApi({
     }),
   }),
 });
-
 
 export const { useUpdatePasswordMutation } = resetPasswordApi;


### PR DESCRIPTION
there was a bug where the auth cookie needed to complete password reset was not being included in the request to the backend for handling password update. The flag was added to make sure that the auth cookie is included in the request header when submitting the new password