### PR TITLE
ES-126: update localhost to base url variable

### DIFF
--- a/src/features/DigitalLease/api/leaseApi.ts
+++ b/src/features/DigitalLease/api/leaseApi.ts
@@ -28,13 +28,13 @@ export const leaseApi = createApi({
     endpoints: (builder) => ({
         getLease: builder.query<TenantLeaseData, void>({
             query: () => ({
-                url: 'leases/view',
+                url: '/leases/view',
                 method: 'GET',
             }),
         }),
         signLease: builder.mutation({
             query: ({ leaseId, signature }: signBodyParams) => ({
-                url: 'leases/sign',
+                url: '/leases/sign',
                 method: 'POST',
                 body: { leaseId, signature }
             }),

--- a/src/features/Login/api/loginApi.ts
+++ b/src/features/Login/api/loginApi.ts
@@ -5,16 +5,18 @@ type Login = {
   password: string;
 };
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 export const loginApi = createApi({
   reducerPath: 'loginApi',
   baseQuery: fetchBaseQuery({
-    baseUrl: 'http://localhost:3000/',
+    baseUrl: API_BASE_URL,
     credentials: 'include',
   }),
   endpoints: (builder) => ({
     login: builder.mutation({
       query: ({ email, password }: Login) => ({
-        url: 'auth/signin',
+        url: '/auth/signin',
         method: 'POST',
         body: { email, password },
       }),

--- a/src/features/PasswordReset/api/passwordresetApi.ts
+++ b/src/features/PasswordReset/api/passwordresetApi.ts
@@ -1,14 +1,16 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 export const passwordResetApi = createApi({
   reducerPath: 'passwordResetApi',
   baseQuery: fetchBaseQuery({
-    baseUrl: 'http://localhost:3000/',
+    baseUrl: API_BASE_URL,
   }),
   endpoints: (builder) => ({
     resetPassword: builder.mutation({
       query: (email: string) => ({
-        url: 'auth/forgot-password',
+        url: '/auth/forgot-password',
         method: 'POST',
         body: { email },
       }),

--- a/src/features/ResetPassword/api/Resetpasswordapi.ts
+++ b/src/features/ResetPassword/api/Resetpasswordapi.ts
@@ -1,12 +1,14 @@
 import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react';
 
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 export const resetPasswordApi = createApi({
   reducerPath: 'resetPasswordApi',
-  baseQuery: fetchBaseQuery({ baseUrl: 'http://localhost:3000/', credentials: 'include' }),
+  baseQuery: fetchBaseQuery({ baseUrl: API_BASE_URL, credentials: 'include' }),
   endpoints: (builder) => ({
     updatePassword: builder.mutation<void, { newPassword: string }>({
       query: (body) => ({
-        url: 'auth/update-password',
+        url: '/auth/update-password',
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/features/Services/userSlice.ts
+++ b/src/features/Services/userSlice.ts
@@ -7,17 +7,20 @@ interface Complaint {
   extraDetails?: string;
   img?: string;
 }
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
 export const userApi = createApi({
   reducerPath: 'userApi',
   baseQuery: fetchBaseQuery({
-    baseUrl: 'http://localhost:3000/',
+    baseUrl: API_BASE_URL,
     credentials: 'include',
   }),
 
   endpoints: (builder) => ({
     // Remove
     getAllUsers: builder.query<User, void>({
-      //Calls the endpoint at http://localhost:3000/api/ping
+      //Calls the endpoint at API_BASE_URL/api/ping
       query: () => `ping`,
     }),
     sendComplaint: builder.mutation({

--- a/src/features/auth/Register.tsx
+++ b/src/features/auth/Register.tsx
@@ -28,6 +28,7 @@ const RegisterPage = () => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [verificationSent, setVerificationSent] = useState(false);
+  const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
     const { name, value } = e.target;
@@ -64,9 +65,8 @@ const RegisterPage = () => {
     if (!validateForm()) return;
 
     setLoading(true);
-
     try {
-      const response = await fetch('http://localhost:3000/auth/register', {
+      const response = await fetch(`${API_BASE_URL}/auth/register`, {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_API_BASE_URL: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
Quick chore to update all instances of localhost to `VITE_API_BASE_URL`.

Also updated `src/vite-env.d.ts` file to make sure Typescript recognizes the variable.

Since these links are now pointing to the deployed API service, testing the deploy app will likely throw a CORS error. Will need to sync a dev frontend service with the dev backend to figure out how to make testing more feasable.