### PR TITLE
ES-117: add dob and phone to req body

### DIFF
--- a/src/features/auth/Register.tsx
+++ b/src/features/auth/Register.tsx
@@ -74,6 +74,8 @@ const RegisterPage = () => {
         body: JSON.stringify({
           email: formData.email,
           password: formData.password,
+          phone: formData.phone,
+          dob: formData.dob,
         }),
       });
 


### PR DESCRIPTION
## Quick Fix
**Issue**:
`phone` and `dob` not being updated in the tenants table during user registration

**Fix**:
The data was not being included in request body so this adds that info to the request so the backend can handle the update.