### PR TITLE
ES-150: chore(register): Make DOB field in the Register form required

### DIFF
--- a/src/features/auth/Register.tsx
+++ b/src/features/auth/Register.tsx
@@ -175,13 +175,14 @@ const RegisterPage = () => {
                 required
               />
               <TextField
-                label=' '
+                label=''
                 name='dob'
                 type='date'
                 fullWidth
                 margin='normal'
                 value={formData.dob}
                 onChange={handleChange}
+                required
               />
               <TextField
                 label='Password'


### PR DESCRIPTION
### Description
- Added a required prop to the dob field so to prevent the user from submitting without entering their dob, which was causing the browser to crash.