### PR TITLE
feat: connect management ui to db

### DIFF
--- a/src/features/Management/ComplaintCard.tsx
+++ b/src/features/Management/ComplaintCard.tsx
@@ -2,18 +2,20 @@ import { Card, Typography, Stack } from '@mui/material';
 interface complaintCardProps {
   title: string;
   description: string;
-  tenantName: string;
-  status: string;
+  tenantName?: string;
+  status?: string;
   priority: string;
   complaintId: number;
+  createdAt: string;
 }
 function ComplaintCard({
   title,
   description,
-  tenantName,
-  status,
+  // tenantName,
+  // status,
   priority,
   complaintId,
+  createdAt,
 }: complaintCardProps) {
   let priorityColor: string = '';
   if (priority == 'high') {
@@ -25,7 +27,11 @@ function ComplaintCard({
   if (priority == 'low') {
     priorityColor = 'gray';
   }
-  console.log(priority, title);
+  const formattedDate = new Date(createdAt).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
   return (
     <Card
       key={complaintId}
@@ -39,13 +45,13 @@ function ComplaintCard({
       </Typography>
       <Stack sx={{ flexDirection: { sm: 'column', md: 'row' }, justifyContent: 'space-between' }}>
         <Typography>
-          <b>Issuing Tenant: </b>
-          {tenantName}
+          <b>Date Reported: </b>
+          {formattedDate}
         </Typography>
-        {/* <Typography>
-          <b>Status: </b>
-          {status}
-        </Typography> */}
+        <Typography>
+          <b>Complaint ID: </b>
+          {complaintId}
+        </Typography>
       </Stack>
     </Card>
   );

--- a/src/features/Management/ComplaintCard.tsx
+++ b/src/features/Management/ComplaintCard.tsx
@@ -16,15 +16,16 @@ function ComplaintCard({
   complaintId,
 }: complaintCardProps) {
   let priorityColor: string = '';
-  if (priority === 'High') {
+  if (priority == 'high') {
     priorityColor = 'red';
   }
-  if (priority === 'Medium') {
+  if (priority == 'medium') {
     priorityColor = 'yellow';
   }
-  if (priority === 'Low') {
+  if (priority == 'low') {
     priorityColor = 'gray';
   }
+  console.log(priority, title);
   return (
     <Card
       key={complaintId}
@@ -41,10 +42,10 @@ function ComplaintCard({
           <b>Issuing Tenant: </b>
           {tenantName}
         </Typography>
-        <Typography>
+        {/* <Typography>
           <b>Status: </b>
           {status}
-        </Typography>
+        </Typography> */}
       </Stack>
     </Card>
   );

--- a/src/features/Management/ComplaintCard.tsx
+++ b/src/features/Management/ComplaintCard.tsx
@@ -18,13 +18,13 @@ function ComplaintCard({
   createdAt,
 }: complaintCardProps) {
   let priorityColor: string = '';
-  if (priority == 'high') {
+  if (priority == 'High') {
     priorityColor = 'red';
   }
-  if (priority == 'medium') {
+  if (priority == 'Medium') {
     priorityColor = 'yellow';
   }
-  if (priority == 'low') {
+  if (priority == 'Low') {
     priorityColor = 'gray';
   }
   const formattedDate = new Date(createdAt).toLocaleDateString('en-US', {

--- a/src/features/Management/ManagementDashboard.tsx
+++ b/src/features/Management/ManagementDashboard.tsx
@@ -1,6 +1,6 @@
 import { Container, Stack, Typography } from '@mui/material';
 import ComplaintCard from './ComplaintCard';
-
+import { useGetAllComplaintsQuery } from '../Services/userSlice';
 //Example Complaint obj
 interface complaintCardProps {
   title: string;
@@ -46,36 +46,47 @@ const complaintsExample = [
     complaintId: 4,
   },
 ];
+
 function ManagementDashboard() {
-  return (
-    <Container>
-      <Stack sx={{ marginBottom: 4, marginTop: 4 }}>
-        <Typography variant='h3'> Complaints</Typography>
-      </Stack>
-      <Stack>
-        {complaintsExample.map(
-          ({
-            title,
-            description,
-            tenantName,
-            status,
-            priority,
-            complaintId,
-          }: complaintCardProps) => (
-            <ComplaintCard
-              key={complaintId}
-              title={title}
-              description={description}
-              tenantName={tenantName}
-              status={status}
-              priority={priority}
-              complaintId={complaintId}
-            />
-          ),
-        )}
-      </Stack>
-    </Container>
-  );
+  const { data, error, isLoading } = useGetAllComplaintsQuery();
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error</div>;
+  if (!data) return <div>No data</div>;
+
+  if (data) {
+    console.log(data);
+    const complaintsArr = data.complaints;
+    return (
+      <Container>
+        <Stack sx={{ marginBottom: 4, marginTop: 4 }}>
+          <Typography variant='h3'> Complaints</Typography>
+        </Stack>
+        <Stack>
+          {complaintsArr.map(
+            ({
+              description: description,
+              complaintTitle: title,
+              tenantId: tenantName,
+              resolvedAt: status,
+              priority: priority,
+              id: complaintId,
+            }: any) => (
+              <ComplaintCard
+                key={complaintId}
+                title={title}
+                description={description}
+                tenantName={tenantName}
+                status={status}
+                priority={priority}
+                complaintId={complaintId}
+              />
+            ),
+          )}
+        </Stack>
+      </Container>
+    );
+  }
 }
 
 export default ManagementDashboard;

--- a/src/features/Management/ManagementDashboard.tsx
+++ b/src/features/Management/ManagementDashboard.tsx
@@ -3,49 +3,14 @@ import ComplaintCard from './ComplaintCard';
 import { useGetAllComplaintsQuery } from '../Services/userSlice';
 //Example Complaint obj
 interface complaintCardProps {
-  title: string;
+  complaintTitle: string;
   description: string;
-  tenantName: string;
-  status: string;
+  tenantName?: string;
+  status?: string;
   priority: string;
-  complaintId: number;
+  id: number;
+  createdAt: string;
 }
-
-const complaintsExample = [
-  {
-    title: 'Leaking Faucet',
-    description: 'The living room was flooded and caused damage to proprety',
-    tenantName: 'Felipe',
-    status: 'Unresolved',
-    priority: 'High',
-    complaintId: 1,
-  },
-  {
-    title: 'Elevator Not Working',
-    description: 'Their are tenants stuck inside',
-    tenantName: 'Taryn',
-    status: 'Unresolved',
-    priority: 'High',
-    complaintId: 2,
-  },
-  {
-    title: 'Loud Music from a neighboring unit',
-    description:
-      'There is music playing from neighbors apartment sometimes usually for a short amount of time',
-    tenantName: 'Melisa',
-    status: 'Resolved',
-    priority: 'Medium',
-    complaintId: 3,
-  },
-  {
-    title: 'Pets not on a leash',
-    description: 'Small cat wonders around complex sometimes',
-    tenantName: 'Eddie',
-    status: 'Unresolved',
-    priority: 'Low',
-    complaintId: 4,
-  },
-];
 
 function ManagementDashboard() {
   const { data, error, isLoading } = useGetAllComplaintsQuery();
@@ -55,7 +20,6 @@ function ManagementDashboard() {
   if (!data) return <div>No data</div>;
 
   if (data) {
-    console.log(data);
     const complaintsArr = data.complaints;
     return (
       <Container>
@@ -67,20 +31,23 @@ function ManagementDashboard() {
             ({
               description: description,
               complaintTitle: title,
-              tenantId: tenantName,
-              resolvedAt: status,
+              // tenantId: tenantName,
+              createdAt: createdAt,
               priority: priority,
               id: complaintId,
-            }: any) => (
-              <ComplaintCard
-                key={complaintId}
-                title={title}
-                description={description}
-                tenantName={tenantName}
-                status={status}
-                priority={priority}
-                complaintId={complaintId}
-              />
+            }: complaintCardProps) => (
+              console.log(complaintsArr),
+              (
+                <ComplaintCard
+                  key={complaintId}
+                  title={title}
+                  description={description}
+                  // tenantName={tenantName}
+                  createdAt={createdAt}
+                  priority={priority}
+                  complaintId={complaintId}
+                />
+              )
             ),
           )}
         </Stack>

--- a/src/features/Services/userSlice.ts
+++ b/src/features/Services/userSlice.ts
@@ -34,7 +34,11 @@ export const userApi = createApi({
         body: complaint,
       }),
     }),
+    getAllComplaints: builder.query<any, void>({
+      query: () => `complaints/get-complaints`,
+      keepUnusedDataFor: 60,
+    }),
   }),
 });
 
-export const { useGetAllUsersQuery, useSendComplaintMutation } = userApi;
+export const { useGetAllUsersQuery, useSendComplaintMutation, useGetAllComplaintsQuery } = userApi;


### PR DESCRIPTION
### Description
On the management UI we can now display complaints from the DB, they will show along with the date the complaint was reported, complaint id, complaint category, and title

### Testing
Simply go to tenant support, add a complaint, then navigate to /manage-complaints and there you should get a list of all the complaints

Originally from #67